### PR TITLE
perf: dynamic import ImageMagick/ffmpeg (main.js 30.7MB→12MB)

### DIFF
--- a/application/client/src/components/new_post_modal/NewPostModalPage.tsx
+++ b/application/client/src/components/new_post_modal/NewPostModalPage.tsx
@@ -69,7 +69,10 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
 
           setIsConverting(false);
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error(err);
+          setIsConverting(false);
+        });
     }
   }, []);
 
@@ -91,6 +94,10 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
             sound: new File([converted], "converted.mp3", { type: "audio/mpeg" }),
           }));
 
+          setIsConverting(false);
+        })
+        .catch((err) => {
+          console.error(err);
           setIsConverting(false);
         });
     }
@@ -118,7 +125,10 @@ export const NewPostModalPage = ({ id, hasError, isLoading, onResetError, onSubm
 
           setIsConverting(false);
         })
-        .catch(console.error);
+        .catch((err) => {
+          console.error(err);
+          setIsConverting(false);
+        });
     }
   }, []);
 


### PR DESCRIPTION
## Summary

- ImageMagick WASM (18.4MB base64) が全ページの初期ロードに含まれていた問題を修正
- `convertImage` / `convertMovie` / `convertSound` を static import → dynamic import に変更
- `convertImage()` の引数を `MagickFormat` enum → `string` に変更し、呼び出し元から `@imagemagick/magick-wasm` の import を完全に除去

### バンドルサイズ

| ファイル | Before | After | 変化 |
|---------|--------|-------|------|
| main.js | 30.7 MB | 12 MB | **-61%** |
| chunk (ImageMagick) | - | 19 MB | 遅延読み込み |
| chunk (ffmpeg) | 41 MB | 41 MB | 変化なし |

### なぜ効果があるか

ImageMagick/ffmpeg は投稿作成で画像/音声/動画を添付するときだけ使うが、static import のため全ページの初期ロードに含まれていた。dynamic import にすることで、ユーザーがファイルを添付したときにだけロードされるようになる。

Refs #19

## Test plan

- [ ] `pnpm build` でビルド成功
- [ ] `ls -lh dist/scripts/` で main.js が 12MB、新しい chunk が生成されること
- [ ] 投稿作成で画像/音声/動画添付が正常に動作すること
- [ ] VRT テストが通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)