### PR TITLE
perf: remove load event listener blocking FCP/LCP

### DIFF
--- a/application/client/src/index.tsx
+++ b/application/client/src/index.tsx
@@ -5,12 +5,10 @@ import { BrowserRouter } from "react-router";
 import { AppContainer } from "@web-speed-hackathon-2026/client/src/containers/AppContainer";
 import { store } from "@web-speed-hackathon-2026/client/src/store";
 
-window.addEventListener("load", () => {
-  createRoot(document.getElementById("app")!).render(
-    <Provider store={store}>
-      <BrowserRouter>
-        <AppContainer />
-      </BrowserRouter>
-    </Provider>,
-  );
-});
+createRoot(document.getElementById("app")!).render(
+  <Provider store={store}>
+    <BrowserRouter>
+      <AppContainer />
+    </BrowserRouter>
+  </Provider>,
+);


### PR DESCRIPTION
## Summary
- `window.addEventListener("load")` を削除し、React描画を即座に開始するように変更
- Webpackの `defer` 属性によりDOMパース完了後にスクリプトが実行されるため、イベントリスナーは不要

## Why
`load` イベントは画像89MB+フォント13MBを含む**全リソースのダウンロード完了後**に発火する。
これにより React が一切描画されず、全9ページの FCP/LCP/SI が 0点になっていた。

## Test plan
- [ ] VRTテスト通過確認
- [ ] Lighthouseスコアで FCP/LCP が 0 → 正の値に改善

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)