### PR TITLE
perf: narrow Babel targets to latest Chrome

### DIFF
--- a/application/client/babel.config.js
+++ b/application/client/babel.config.js
@@ -4,7 +4,7 @@ module.exports = {
     [
       "@babel/preset-env",
       {
-        targets: "> 0.5%, not dead",
+        targets: "last 1 Chrome version",
         corejs: "3",
         modules: false,
         useBuiltIns: "usage",


### PR DESCRIPTION
## Summary
- Babel の `targets` を `"> 0.5%, not dead"` → `"last 1 Chrome version"` に変更
- 不要な core-js polyfill（推定100〜200KB）がバンドルから除外される

## Why
競技ルールでは Chrome 最新のみ対応すればよい。
広すぎる targets により `useBuiltIns: "usage"` が大量の polyfill を自動挿入していた。
Chrome 最新は ES2015+ をネイティブサポートしており、polyfill はほぼ不要。

## Test plan
- [ ] VRTテスト通過確認
- [ ] ビルド後のバンドルサイズ削減確認
- [ ] TBTスコア改善確認

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)