### PR TITLE
perf: remove route code splitting and fix misc client issues

### DIFF
--- a/application/client/src/components/user_profile/UserProfileHeader.tsx
+++ b/application/client/src/components/user_profile/UserProfileHeader.tsx
@@ -24,7 +24,8 @@ export const UserProfileHeader = ({ user }: Props) => {
   return (
     <header className="relative">
       <div
-        className={`h-32 ${averageColor ? `bg-[${averageColor}]` : "bg-cax-surface-subtle"}`}
+        className={`h-32 ${averageColor !== null ? "" : "bg-cax-surface-subtle"}`}
+        style={averageColor !== null ? { backgroundColor: averageColor } : undefined}
       ></div>
       <div className="border-cax-border bg-cax-surface-subtle absolute left-2/4 m-0 h-28 w-28 -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded-full border sm:h-32 sm:w-32">
         <img

--- a/application/client/src/containers/AppContainer.tsx
+++ b/application/client/src/containers/AppContainer.tsx
@@ -1,61 +1,20 @@
-import { lazy, Suspense, useCallback, useEffect, useId, useState } from "react";
+import { useCallback, useEffect, useId, useState } from "react";
 import { Helmet, HelmetProvider } from "react-helmet";
 import { Route, Routes, useLocation, useNavigate } from "react-router";
 
 import { AppPage } from "@web-speed-hackathon-2026/client/src/components/application/AppPage";
+import { AuthModalContainer } from "@web-speed-hackathon-2026/client/src/containers/AuthModalContainer";
+import { CrokContainer } from "@web-speed-hackathon-2026/client/src/containers/CrokContainer";
+import { DirectMessageContainer } from "@web-speed-hackathon-2026/client/src/containers/DirectMessageContainer";
+import { DirectMessageListContainer } from "@web-speed-hackathon-2026/client/src/containers/DirectMessageListContainer";
+import { NewPostModalContainer } from "@web-speed-hackathon-2026/client/src/containers/NewPostModalContainer";
 import { NotFoundContainer } from "@web-speed-hackathon-2026/client/src/containers/NotFoundContainer";
+import { PostContainer } from "@web-speed-hackathon-2026/client/src/containers/PostContainer";
+import { SearchContainer } from "@web-speed-hackathon-2026/client/src/containers/SearchContainer";
+import { TermContainer } from "@web-speed-hackathon-2026/client/src/containers/TermContainer";
+import { TimelineContainer } from "@web-speed-hackathon-2026/client/src/containers/TimelineContainer";
+import { UserProfileContainer } from "@web-speed-hackathon-2026/client/src/containers/UserProfileContainer";
 import { fetchJSON, sendJSON } from "@web-speed-hackathon-2026/client/src/utils/fetchers";
-
-const TimelineContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/TimelineContainer").then((mod) => ({
-    default: mod.TimelineContainer,
-  })),
-);
-const DirectMessageListContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/DirectMessageListContainer").then(
-    (mod) => ({ default: mod.DirectMessageListContainer }),
-  ),
-);
-const DirectMessageContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/DirectMessageContainer").then((mod) => ({
-    default: mod.DirectMessageContainer,
-  })),
-);
-const SearchContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/SearchContainer").then((mod) => ({
-    default: mod.SearchContainer,
-  })),
-);
-const UserProfileContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/UserProfileContainer").then((mod) => ({
-    default: mod.UserProfileContainer,
-  })),
-);
-const PostContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/PostContainer").then((mod) => ({
-    default: mod.PostContainer,
-  })),
-);
-const TermContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/TermContainer").then((mod) => ({
-    default: mod.TermContainer,
-  })),
-);
-const CrokContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/CrokContainer").then((mod) => ({
-    default: mod.CrokContainer,
-  })),
-);
-const AuthModalContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/AuthModalContainer").then((mod) => ({
-    default: mod.AuthModalContainer,
-  })),
-);
-const NewPostModalContainer = lazy(() =>
-  import("@web-speed-hackathon-2026/client/src/containers/NewPostModalContainer").then((mod) => ({
-    default: mod.NewPostModalContainer,
-  })),
-);
 
 export const AppContainer = () => {
   const { pathname } = useLocation();
@@ -102,38 +61,32 @@ export const AppContainer = () => {
         newPostModalId={newPostModalId}
         onLogout={handleLogout}
       >
-        <Suspense fallback={null}>
-          <Routes>
-            <Route element={<TimelineContainer />} path="/" />
-            <Route
-              element={
-                <DirectMessageListContainer activeUser={activeUser} authModalId={authModalId} />
-              }
-              path="/dm"
-            />
-            <Route
-              element={<DirectMessageContainer activeUser={activeUser} authModalId={authModalId} />}
-              path="/dm/:conversationId"
-            />
-            <Route element={<SearchContainer />} path="/search" />
-            <Route element={<UserProfileContainer />} path="/users/:username" />
-            <Route element={<PostContainer />} path="/posts/:postId" />
-            <Route element={<TermContainer />} path="/terms" />
-            <Route
-              element={<CrokContainer activeUser={activeUser} authModalId={authModalId} />}
-              path="/crok"
-            />
-            <Route element={<NotFoundContainer />} path="*" />
-          </Routes>
-        </Suspense>
+        <Routes>
+          <Route element={<TimelineContainer />} path="/" />
+          <Route
+            element={
+              <DirectMessageListContainer activeUser={activeUser} authModalId={authModalId} />
+            }
+            path="/dm"
+          />
+          <Route
+            element={<DirectMessageContainer activeUser={activeUser} authModalId={authModalId} />}
+            path="/dm/:conversationId"
+          />
+          <Route element={<SearchContainer />} path="/search" />
+          <Route element={<UserProfileContainer />} path="/users/:username" />
+          <Route element={<PostContainer />} path="/posts/:postId" />
+          <Route element={<TermContainer />} path="/terms" />
+          <Route
+            element={<CrokContainer activeUser={activeUser} authModalId={authModalId} />}
+            path="/crok"
+          />
+          <Route element={<NotFoundContainer />} path="*" />
+        </Routes>
       </AppPage>
 
-      <Suspense fallback={null}>
-        <AuthModalContainer id={authModalId} onUpdateActiveUser={setActiveUser} />
-      </Suspense>
-      <Suspense fallback={null}>
-        <NewPostModalContainer id={newPostModalId} />
-      </Suspense>
+      <AuthModalContainer id={authModalId} onUpdateActiveUser={setActiveUser} />
+      <NewPostModalContainer id={newPostModalId} />
     </HelmetProvider>
   );
 };

--- a/application/client/src/index.css
+++ b/application/client/src/index.css
@@ -1,3 +1,4 @@
+@layer normalize, theme, base, components, utilities;
 @import "tailwindcss";
 @import "normalize.css" layer(normalize);
 

--- a/application/client/src/utils/fetchers.ts
+++ b/application/client/src/utils/fetchers.ts
@@ -38,6 +38,7 @@ export async function sendFile<T>(url: string, file: File): Promise<T> {
     body: file,
   });
   if (!response.ok) {
+    await response.body?.cancel();
     throw new FetchError(response);
   }
   return response.json() as Promise<T>;

--- a/application/client/src/utils/fetchers.ts
+++ b/application/client/src/utils/fetchers.ts
@@ -14,6 +14,7 @@ export class FetchError extends Error {
 export async function fetchBinary(url: string): Promise<ArrayBuffer> {
   const response = await fetch(url);
   if (!response.ok) {
+    await response.body?.cancel();
     throw new FetchError(response);
   }
   return response.arrayBuffer();
@@ -22,6 +23,7 @@ export async function fetchBinary(url: string): Promise<ArrayBuffer> {
 export async function fetchJSON<T>(url: string): Promise<T> {
   const response = await fetch(url);
   if (!response.ok) {
+    await response.body?.cancel();
     throw new FetchError(response);
   }
   return response.json() as Promise<T>;

--- a/application/client/webpack.config.js
+++ b/application/client/webpack.config.js
@@ -59,7 +59,7 @@ const config = {
     chunkFilename: "scripts/chunk-[contenthash].js",
     filename: "scripts/[name]-[contenthash].js",
     path: DIST_PATH,
-    publicPath: "auto",
+    publicPath: "/",
     clean: true,
   },
   plugins: [


### PR DESCRIPTION
## Summary
- ルートレベルのコード分割（`lazy()` + `Suspense`）を削除し、静的importに変更。ナビゲーション時の動的チャンクロードのオーバーヘッドを排除
- 動的Tailwindクラス `bg-[${averageColor}]` をinline styleに修正（JITが動的値を生成できない問題の対応）
- `@layer` 宣言を追加してCSSカスケード順序を明示化
- fetchエラー時に `response.body?.cancel()` を追加してリソースリークを防止
- webpack `publicPath` を `"auto"` から `"/"` に変更してアセット解決を安定化

## Why
- **コード分割の削除**: 小規模SPAではルート単位のコード分割がかえってパフォーマンスを悪化させる。各ページ遷移ごとにネットワークリクエストが発生し、TBTやLCPに悪影響を与える
- **Tailwind動的クラス修正**: Tailwind JITはビルド時に静的解析するため、`bg-[${variable}]` のような動的クラスは生成されない。inline styleで正しく適用
- **@layer宣言**: CSSの読み込み順序に依存せずスタイルの優先度を保証
- **response.body.cancel()**: エラー時にレスポンスボディを明示的にキャンセルしないとブラウザがコネクションを保持し続ける
- **publicPath**: `"auto"` は [AutoPublicPathRuntimeModule](https://github.com/webpack/webpack/blob/main/lib/runtime/AutoPublicPathRuntimeModule.js) のランタイムコード（~15行のJS）を注入し、`document.currentScript` 等から配信元URLを実行時に推論する。このアプリは常にルート（`/`）から配信されるため、ランタイム推論は不要。静的に `"/"` を指定して余計なコードを排除

## Test plan
- [ ] `pnpm build` が成功すること
- [ ] 各ページが正常に表示されること
- [ ] VRT/E2Eテストがパスすること
- [ ] UserProfileHeaderのバナー色が正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)