### PR TITLE
perf: remove 2^18 loop from InfiniteScroll scroll handler

### DIFF
--- a/application/client/src/components/foundation/InfiniteScroll.tsx
+++ b/application/client/src/components/foundation/InfiniteScroll.tsx
@@ -13,10 +13,7 @@ export const InfiniteScroll = ({ children, fetchMore, items }: Props) => {
 
   useEffect(() => {
     const handler = () => {
-      // 念の為 2の18乗 回、最下部かどうかを確認する
-      const hasReached = Array.from(Array(2 ** 18), () => {
-        return window.innerHeight + Math.ceil(window.scrollY) >= document.body.offsetHeight;
-      }).every(Boolean);
+      const hasReached = window.innerHeight + Math.ceil(window.scrollY) >= document.body.offsetHeight;
 
       // 画面最下部にスクロールしたタイミングで、登録したハンドラを呼び出す
       if (hasReached && !prevReachedRef.current) {


### PR DESCRIPTION
## Summary
- `InfiniteScroll` のスクロールハンドラーから **2^18（262,144回）ループ** を削除
- 毎スクロールイベントで262,144回の同一DOM読み取りがメインスレッドを数百msブロックしていた
- 1回の比較で十分なため、ループを単純な比較に置き換え

## Why
TBT（Total Blocking Time）はスコアリングで **x30 の最高重み**。全ページでTBT ≈ 0点（合計 ~4/270点）だったのは、このループが原因。

## Test plan
- [ ] VRTテスト通過
- [ ] InfiniteScroll が正常にページ末尾を検知して追加読み込みすること
- [ ] スクロール時にメインスレッドがブロックされないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)